### PR TITLE
Use CUDA_HOME when compiling nn module

### DIFF
--- a/lib/csrc/nn/setup.py
+++ b/lib/csrc/nn/setup.py
@@ -1,6 +1,6 @@
 import os
 
-cuda_include='/usr/local/cuda-9.0/include'
+cuda_include=os.path.join(os.environ.get('CUDA_HOME'), 'include')
 os.system('nvcc src/nearest_neighborhood.cu -c -o src/nearest_neighborhood.cu.o -x cu -Xcompiler -fPIC -O2 -arch=sm_52 -I {}'.format(cuda_include))
 
 from cffi import FFI
@@ -16,7 +16,7 @@ ffibuilder.set_source(
     #include "src/ext.h"
     """,
     extra_objects=['src/nearest_neighborhood.cu.o',
-                   '/usr/local/cuda-9.0/lib64/libcudart.so'],
+                   os.path.join(os.environ.get('CUDA_HOME'),'lib64/libcudart.so')],
     libraries=['stdc++']
 )
 


### PR DESCRIPTION
The setup script in the nn module has the CUDA path and version hardcoded. Since the installation instructions already require to set CUDA_HOME, make the nn module also use that environment variable.