### PR TITLE
Update RANSAC Voting for PyTorch (>1.10) & CUDA (>11.1) Compatibility

### DIFF
--- a/lib/csrc/ransac_voting/ransac_voting_gpu.py
+++ b/lib/csrc/ransac_voting/ransac_voting_gpu.py
@@ -103,7 +103,9 @@ def b_inv(b_mat):
     '''
     eye = b_mat.new_ones(b_mat.size(-1)).diag().expand_as(b_mat)
     try:
-        b_inv, _ = torch.solve(eye, b_mat)
+        # b_inv, _ = torch.solve(eye, b_mat)
+        b_inv = torch.linalg.solve(b_mat, eye) # torch.solve is moved to torch.linalg solve
+
     except:
         b_inv = eye
     return b_inv
@@ -139,6 +141,7 @@ def ransac_voting_layer_v3(mask, vertex, round_hyp_num, inlier_thresh=0.999, con
 
         coords = torch.nonzero(cur_mask).float()  # [tn,2]
         coords = coords[:, [1, 0]]
+        cur_mask = cur_mask.ge(1) # Updated masked_select requires boolean instead of 0 and 1
         direct = vertex[bi].masked_select(torch.unsqueeze(torch.unsqueeze(cur_mask, 2), 3))  # [tn,vn,2]
         direct = direct.view([coords.shape[0], vn, 2])
         tn = coords.shape[0]

--- a/lib/csrc/ransac_voting/src/ransac_voting.cpp
+++ b/lib/csrc/ransac_voting/src/ransac_voting.cpp
@@ -2,7 +2,7 @@
 #include <iostream>
 #include <vector>
 
-extern THCState* state;
+// extern THCState* state;
 
 #define CHECK_CUDA(x) AT_ASSERTM(x.type().is_cuda(), #x " must be a CUDA tensor")
 #define CHECK_CONTIGUOUS(x) AT_ASSERTM(x.is_contiguous(), #x " must be contiguous")


### PR DESCRIPTION
ℹ️ Ensure Compatibility with Newer PyTorch and CUDA Versions for RANSAC Voting Layer

🚀 Summary:
This commit updates the RANSAC voting module to ensure compatibility with the latest PyTorch and CUDA versions.

🔄 Changes Made:
- Pytorch has removed `Thc/thc.h ` headers from version >11.1 which gives compilation errors. Commented `extern THCState* state; ` in `ransac_voting.cpp`
- Replaced the `torch.solve()` with `torch.linalg.solve()` for newer version.
- Applied `tensor.ge()` function on the mask as `tensor.masked_select` expects a boolean tensor array in newer versions.

📋 Additional Notes:
- Requirements.txt should be updated to work with newer versions as well. 


🔧 Dependencies:
- PyTorch: >1.11
- CUDA: >11.1

🧪 Testing:
- Ran comprehensive tests to validate the compatibility with PyTorch [2.1.2] and CUDA [11.8].
- Verified that the RANSAC voting module performs as expected.

👏 Acknowledgments: Thanks to the authors for sharing code for this valuable research.


📅 Date: 21st Jan, 2024

